### PR TITLE
8 allow babel configuration to be overriden extended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- ability to implicitly override or explicitly extend default babel configuration ([#8](https://github.com/JBKLabs/react-dev/issues/8))
+
 ## [0.0.1] - 2019-09-19
 ### Added
 - initial `configure` script

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ In order of precedence, each of the following paths will override the babel conf
 - `.babel.config.js`
 - `package.json#babel`
 
-You can use the [standard babel documentation](https://babeljs.io/docs/en/configuration) for how to do so.
+You can reference the [standard babel documentation](https://babeljs.io/docs/en/configuration) for how to do so.
 
 If you want to extend the configuration provided by `@jbknowledge/react-dev` rather than replace it, import `config.babel` from `@jbknowledge/react-dev` like the following:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,54 @@ npm install @jbknowledge/react-dev
 
 ## Overriding Configuration
 
+### Eslint
+
+TODO
+
+### Prettier
+
+TODO
+
+### Babel
+
+In order of precedence, each of the following paths will override the babel configuration provided by `@jbknowledge/react-dev`
+
+- `.babelrc`
+- `.babelrc.js`
+- `.babel.config.js`
+- `package.json#babel`
+
+You can use the [standard babel documentation](https://babeljs.io/docs/en/configuration) for how to do so.
+
+If you want to extend the configuration provided by `@jbknowledge/react-dev` rather than replace it, import `config.babel` from `@jbknowledge/react-dev` like the following:
+
+```js
+const { babel } = require('@jbknowledge/react-dev');
+
+module.exports = {
+  presets: babel.presets.default,
+  // etc
+}
+```
+
+`config.babel` has the following schema at this time:
+
+```json
+{
+  "presets": {
+    "default": [...presets],
+  },
+  "plugins": {
+    "default": [...plugins],
+    "byName": {
+      [pluginName]: {...pluginSettings}
+    }
+  }
+}
+```
+
+### Webpack
+
 TODO
 
 ## Contributors

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { defaults: babel } = require('./src/config/babel');
+const { defaultConfig: babel } = require('./src/config/babel');
 
 module.exports = {
   babel

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+const { defaults: babel } = require('./src/config/babel');
+
+module.exports = {
+  babel
+};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const { defaultConfig: babel } = require('./src/config/babel');
+const babel = require('./src/config/babel');
 
 module.exports = {
   babel

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const babel = require('./src/config/babel');
+const defaults = require('./src/config/defaults');
 
-module.exports = {
-  babel
-};
+module.exports = defaults;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@jbknowledge/dev",
-  "version": "0.0.7",
+  "name": "@jbknowledge/react-dev",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-plugin-module-resolver": "3.2.0",
     "babel-preset-react-app": "9.0.1",
     "case-sensitive-paths-webpack-plugin": "2.2.0",
+    "chalk": "2.4.2",
     "cross-spawn": "7.0.0",
     "css-loader": "3.0.0",
     "escape-string-regexp": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "npm": ">= 5"
   },
   "scripts": {
-    "lint": "node src lint"
+    "lint": "node src/scripts lint"
   },
+  "main": "index.js",
   "bin": {
-    "jbk-scripts": "src/index.js"
+    "jbk-scripts": "src/scripts/index.js"
   },
   "homepage": "https://github.com/JBKLabs/react-dev",
   "bugs": {

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -3,9 +3,7 @@ const defaults = require('./defaults');
 module.exports = (api) => {
   api.cache(true);
   return {
-    presets: defaults.babel.presets,
-    plugins: Object
-      .values(defaults.babel.plugins)
-      .map(p => p.formatted),
+    presets: defaults.babel.presets.default,
+    plugins: defaults.babel.plugins.default
   }
 };

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -9,7 +9,7 @@ const unformattedPlugins = {
   }
 }
 
-const defaults = {
+const defaultConfig = {
   presets: [
     require.resolve('@babel/preset-env'),
     require.resolve('@babel/preset-react')
@@ -28,14 +28,14 @@ const defaults = {
   }
 };
 
-module.exports.defaults = defaults;
+module.exports.defaultConfig = defaultConfig;
 
 module.exports = (api) => {
   api.cache(true);
   return {
-    presets: defaults.presets,
+    presets: defaultConfig.presets,
     plugins: Object
-      .values(defaults.plugins)
+      .values(defaultConfig.plugins)
       .map(p => p.formatted),
   }
 };

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -1,41 +1,11 @@
-const unformattedPlugins = {
-  'babel-plugin-module-resolver': {
-    path: require.resolve('babel-plugin-module-resolver'),
-    root: ['.'],
-    alias: {
-      '~': '.',
-      src: './src'
-    }
-  }
-}
-
-const defaultConfig = {
-  presets: [
-    require.resolve('@babel/preset-env'),
-    require.resolve('@babel/preset-react')
-  ],
-  plugins: {
-    'babel-plugin-module-resolver': {
-      formatted: [
-        unformattedPlugins['babel-plugin-module-resolver'].path,
-        {
-          root: unformattedPlugins['babel-plugin-module-resolver'].root,
-          alias: unformattedPlugins['babel-plugin-module-resolver'].alias
-        }
-      ],
-      opt: unformattedPlugins['babel-plugin-module-resolver']
-    }
-  }
-};
-
-module.exports.defaultConfig = defaultConfig;
+const defaults = require('./defaults');
 
 module.exports = (api) => {
   api.cache(true);
   return {
-    presets: defaultConfig.presets,
+    presets: defaults.babel.presets,
     plugins: Object
-      .values(defaultConfig.plugins)
+      .values(defaults.babel.plugins)
       .map(p => p.formatted),
   }
 };

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -1,3 +1,14 @@
+const unformattedPlugins = {
+  'babel-plugin-module-resolver': {
+    path: require.resolve('babel-plugin-module-resolver'),
+    root: ['.'],
+    alias: {
+      '~': '.',
+      src: './src'
+    }
+  }
+}
+
 const defaults = {
   presets: [
     require.resolve('@babel/preset-env'),
@@ -5,14 +16,14 @@ const defaults = {
   ],
   plugins: {
     'babel-plugin-module-resolver': {
-      path: require.resolve('babel-plugin-module-resolver'),
-      settings: {
-        root: ['.'],
-        alias: {
-          '~': '.',
-          src: './src'
+      formatted: [
+        unformattedPlugins['babel-plugin-module-resolver'].path,
+        {
+          root: unformattedPlugins['babel-plugin-module-resolver'].root,
+          alias: unformattedPlugins['babel-plugin-module-resolver'].alias
         }
-      }
+      ],
+      opt: unformattedPlugins['babel-plugin-module-resolver']
     }
   }
 };
@@ -23,11 +34,8 @@ module.exports = (api) => {
   api.cache(true);
   return {
     presets: defaults.presets,
-    plugins: [
-      [
-        defaults.plugins['babel-plugin-module-resolver'].path,
-        { ...defaults.plugins['babel-plugin-module-resolver'].settings }
-      ]
-    ]
+    plugins: Object
+      .values(defaults.plugins)
+      .map(p => p.formatted),
   }
 };

--- a/src/config/babel.js
+++ b/src/config/babel.js
@@ -1,21 +1,33 @@
+const defaults = {
+  presets: [
+    require.resolve('@babel/preset-env'),
+    require.resolve('@babel/preset-react')
+  ],
+  plugins: {
+    'babel-plugin-module-resolver': {
+      path: require.resolve('babel-plugin-module-resolver'),
+      settings: {
+        root: ['.'],
+        alias: {
+          '~': '.',
+          src: './src'
+        }
+      }
+    }
+  }
+};
+
+module.exports.defaults = defaults;
+
 module.exports = (api) => {
   api.cache(true);
   return {
-    presets: [
-      require.resolve('@babel/preset-env'),
-      require.resolve('@babel/preset-react')
-    ],
+    presets: defaults.presets,
     plugins: [
       [
-        require.resolve('babel-plugin-module-resolver'),
-        {
-          root: ['.'],
-          alias: {
-            '~': '.',
-            src: './src'
-          }
-        }
+        defaults.plugins['babel-plugin-module-resolver'].path,
+        { ...defaults.plugins['babel-plugin-module-resolver'].settings }
       ]
     ]
-  };
+  }
 };

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,0 +1,33 @@
+const unformattedBabelPlugins = {
+  'babel-plugin-module-resolver': {
+    path: require.resolve('babel-plugin-module-resolver'),
+    root: ['.'],
+    alias: {
+      '~': '.',
+      src: './src'
+    }
+  }
+}
+
+const babel = {
+  presets: [
+    require.resolve('@babel/preset-env'),
+    require.resolve('@babel/preset-react')
+  ],
+  plugins: {
+    'babel-plugin-module-resolver': {
+      formatted: [
+        unformattedBabelPlugins['babel-plugin-module-resolver'].path,
+        {
+          root: unformattedBabelPlugins['babel-plugin-module-resolver'].root,
+          alias: unformattedBabelPlugins['babel-plugin-module-resolver'].alias
+        }
+      ],
+      opt: unformattedBabelPlugins['babel-plugin-module-resolver']
+    }
+  }
+};
+
+module.exports = {
+  babel
+};

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -1,30 +1,30 @@
-const unformattedBabelPlugins = {
+const babelPlugins = {
   'babel-plugin-module-resolver': {
     path: require.resolve('babel-plugin-module-resolver'),
-    root: ['.'],
-    alias: {
-      '~': '.',
-      src: './src'
+    options: {
+      root: ['.'],
+      alias: {
+        '~': '.',
+        src: './src'
+      }
     }
   }
-}
+};
 
 const babel = {
-  presets: [
-    require.resolve('@babel/preset-env'),
-    require.resolve('@babel/preset-react')
-  ],
+  presets: {
+    default: [
+      require.resolve('@babel/preset-env'),
+      require.resolve('@babel/preset-react')
+    ],
+  },
   plugins: {
-    'babel-plugin-module-resolver': {
-      formatted: [
-        unformattedBabelPlugins['babel-plugin-module-resolver'].path,
-        {
-          root: unformattedBabelPlugins['babel-plugin-module-resolver'].root,
-          alias: unformattedBabelPlugins['babel-plugin-module-resolver'].alias
-        }
-      ],
-      opt: unformattedBabelPlugins['babel-plugin-module-resolver']
-    }
+    default: [
+      [
+        babelPlugins['babel-plugin-module-resolver'].path,
+        { ...babelPlugins['babel-plugin-module-resolver'].options }
+      ]
+    ]
   }
 };
 

--- a/src/config/defaults.js
+++ b/src/config/defaults.js
@@ -24,7 +24,8 @@ const babel = {
         babelPlugins['babel-plugin-module-resolver'].path,
         { ...babelPlugins['babel-plugin-module-resolver'].options }
       ]
-    ]
+    ],
+    byName: babelPlugins
   }
 };
 

--- a/src/config/webpackFactory.js
+++ b/src/config/webpackFactory.js
@@ -10,6 +10,10 @@ const InterpolateHtmlPlugin = require('../util/InterpolateHtmlWebpackPlugin');
 
 const babel = fetchConfig.babel();
 
+if (babel.configurationExists) {
+  console.log(`Babel override detected: ${babel.token}`);
+}
+
 const webpackFactory = (mode) => {
   const isProduction = mode === 'production';
   const isDevelopment = mode === 'development';

--- a/src/config/webpackFactory.js
+++ b/src/config/webpackFactory.js
@@ -10,8 +10,6 @@ const InterpolateHtmlPlugin = require('../util/InterpolateHtmlWebpackPlugin');
 
 const babel = fetchConfig.babel();
 
-console.log(babel);
-
 const webpackFactory = (mode) => {
   const isProduction = mode === 'production';
   const isDevelopment = mode === 'development';

--- a/src/config/webpackFactory.js
+++ b/src/config/webpackFactory.js
@@ -4,7 +4,11 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
 const { appDirectory } = require('../util');
+const fetchConfig = require('../util/fetchConfig');
 const InterpolateHtmlPlugin = require('../util/InterpolateHtmlWebpackPlugin');
+
+
+const babel = fetchConfig.babel();
 
 const webpackFactory = (mode) => {
   const isProduction = mode === 'production';
@@ -39,7 +43,9 @@ const webpackFactory = (mode) => {
             {
               loader: require.resolve('babel-loader'),
               options: {
-                configFile: path.join(__dirname, './babel.js'),
+                configFile: babel.configurationExists
+                  ? babel.path
+                  : path.join(__dirname, './babel.js'),
                 presets: [require.resolve('babel-preset-react-app')]
               }
             }

--- a/src/config/webpackFactory.js
+++ b/src/config/webpackFactory.js
@@ -1,9 +1,10 @@
 const path = require('path');
+const chalk = require('chalk');
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
 
-const { appDirectory } = require('../util');
+const { appDirectory, log } = require('../util');
 const fetchConfig = require('../util/fetchConfig');
 const InterpolateHtmlPlugin = require('../util/InterpolateHtmlWebpackPlugin');
 
@@ -11,7 +12,7 @@ const InterpolateHtmlPlugin = require('../util/InterpolateHtmlWebpackPlugin');
 const babel = fetchConfig.babel();
 
 if (babel.configurationExists) {
-  console.log(`Babel override detected: ${babel.token}`);
+  log('Babel override detected: ' + chalk.cyan(babel.token));
 }
 
 const webpackFactory = (mode) => {

--- a/src/config/webpackFactory.js
+++ b/src/config/webpackFactory.js
@@ -10,6 +10,8 @@ const InterpolateHtmlPlugin = require('../util/InterpolateHtmlWebpackPlugin');
 
 const babel = fetchConfig.babel();
 
+console.log(babel);
+
 const webpackFactory = (mode) => {
   const isProduction = mode === 'production';
   const isDevelopment = mode === 'development';

--- a/src/scripts/build.js
+++ b/src/scripts/build.js
@@ -3,7 +3,7 @@ const shell = require('shelljs');
 const webpack = require('webpack');
 
 const webpackFactory = require('../config/webpackFactory');
-const { appDirectory } = require('../util');
+const { appDirectory, log } = require('../util');
 
 const config = webpackFactory('production');
 
@@ -17,5 +17,5 @@ compiler.run((err) => {
     throw err;
   }
 
-  console.log('successfully built app to /dist');
+  log('successfully built app to /dist');
 });

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -4,6 +4,8 @@
 const path = require('path');
 const spawn = require('cross-spawn');
 
+const { log } = require('../util');
+
 const [executor, , script, ...args] = process.argv;
 
 const handleSignal = (result) => {
@@ -38,7 +40,7 @@ if (script) {
       process.exit(result.status);
     }
   } catch (error) {
-    console.log(`unknown script "${script}"`);
+    log(`unknown script "${script}"`);
   }
 } else {
   console.log('please enter a command.');

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -10,14 +10,14 @@ const handleSignal = (result) => {
   if (result.signal === 'SIGKILL') {
     console.log(
       `The script "${script}" failed because the process exited too early. ` +
-        'This probably means the system ran out of memory or someone called ' +
-        '`kill -9` on the process.'
+      'This probably means the system ran out of memory or someone called ' +
+      '`kill -9` on the process.'
     );
   } else if (result.signal === 'SIGTERM') {
     console.log(
       `The script "${script}" failed because the process exited too early. ` +
-        'Someone might have called `kill` or `killall`, or the system could ' +
-        'be shutting down.'
+      'Someone might have called `kill` or `killall`, or the system could ' +
+      'be shutting down.'
     );
   }
   process.exit(1);
@@ -25,7 +25,7 @@ const handleSignal = (result) => {
 
 if (script) {
   try {
-    const relativeScriptPath = path.join(__dirname, './scripts', script);
+    const relativeScriptPath = path.join(__dirname, script);
     const scriptPath = require.resolve(relativeScriptPath);
 
     const result = spawn.sync(executor, [scriptPath, ...args], {

--- a/src/util/fetchConfig.js
+++ b/src/util/fetchConfig.js
@@ -8,7 +8,11 @@ const { package: pkg } = readPkgUp.sync({
   cwd: fs.realpathSync(process.cwd()),
 });
 
-const buildPath = (...p) => path.join(appDirectory, ...p);
+const buildPath = (...p) => {
+  const builtPath = path.join(appDirectory, ...p);
+  console.log({ builtPath });
+  return builtPath;
+}
 const projectHasFile = (...p) => fs.existsSync(buildPath(...p));
 
 const babel = () => {
@@ -17,7 +21,9 @@ const babel = () => {
     '.babelrc.js',
     '.babel.config.js'
   ].forEach(f => {
-    if (projectHasFile(f)) {
+    const hasFile = projectHasFile(f)
+    console.log({ f, hasFile });
+    if (hasFile) {
       return {
         configurationExists: true,
         path: buildPath(f)

--- a/src/util/fetchConfig.js
+++ b/src/util/fetchConfig.js
@@ -18,16 +18,18 @@ const babel = () => {
     '.babelrc',
     '.babelrc.js',
     '.babel.config.js'
-  ].forEach(f => {
-    if (projectHasFile(f)) {
+  ].forEach(token => {
+    if (projectHasFile(token)) {
       result = {
+        token,
         configurationExists: true,
-        path: buildPath(f)
+        path: buildPath(token)
       };
     }
   })
 
   return result || {
+    token: 'package.json',
     configurationExists: !!pkg.babel
   };
 };

--- a/src/util/fetchConfig.js
+++ b/src/util/fetchConfig.js
@@ -16,6 +16,8 @@ const buildPath = (...p) => {
 const projectHasFile = (...p) => fs.existsSync(buildPath(...p));
 
 const babel = () => {
+  let result = null;
+
   [
     '.babelrc',
     '.babelrc.js',
@@ -24,14 +26,14 @@ const babel = () => {
     const hasFile = projectHasFile(f)
     console.log({ f, hasFile });
     if (hasFile) {
-      return {
+      result = {
         configurationExists: true,
         path: buildPath(f)
       };
     }
   })
 
-  return {
+  return result || {
     configurationExists: !!pkg.babel
   };
 };

--- a/src/util/fetchConfig.js
+++ b/src/util/fetchConfig.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+const readPkgUp = require('read-pkg-up');
+
+const { appDirectory } = require('./');
+
+const { package: pkg } = readPkgUp.sync({
+  cwd: fs.realpathSync(process.cwd()),
+});
+
+const buildPath = (...p) => path.join(appDirectory, ...p);
+const projectHasFile = (...p) => fs.existsSync(buildPath(...p));
+
+const babel = () => {
+  [
+    '.babelrc',
+    '.babelrc.js',
+    '.babel.config.js'
+  ].forEach(f => {
+    if (projectHasFile(f)) {
+      return {
+        configurationExists: true,
+        path: buildPath(f)
+      };
+    }
+  })
+
+  return {
+    configurationExists: !!pkg.babel
+  };
+};
+
+module.exports = {
+  babel
+};

--- a/src/util/fetchConfig.js
+++ b/src/util/fetchConfig.js
@@ -8,11 +8,7 @@ const { package: pkg } = readPkgUp.sync({
   cwd: fs.realpathSync(process.cwd()),
 });
 
-const buildPath = (...p) => {
-  const builtPath = path.join(appDirectory, ...p);
-  console.log({ builtPath });
-  return builtPath;
-}
+const buildPath = (...p) => path.join(appDirectory, ...p);
 const projectHasFile = (...p) => fs.existsSync(buildPath(...p));
 
 const babel = () => {
@@ -23,9 +19,7 @@ const babel = () => {
     '.babelrc.js',
     '.babel.config.js'
   ].forEach(f => {
-    const hasFile = projectHasFile(f)
-    console.log({ f, hasFile });
-    if (hasFile) {
+    if (projectHasFile(f)) {
       result = {
         configurationExists: true,
         path: buildPath(f)

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -3,6 +3,7 @@
 const path = require('path');
 const fs = require('fs');
 const readPkgUp = require('read-pkg-up');
+const chalk = require('chalk');
 
 const { package: pkg, path: pkgPath } = readPkgUp.sync({
   cwd: fs.realpathSync(process.cwd())
@@ -18,8 +19,13 @@ const resolveBin = (moduleName, executable = moduleName) => {
   return fullPath;
 };
 
+const log = (message) => {
+  console.log(chalk.keyword('salmon')('[jbk-scripts]: ') + message);
+};
+
 module.exports = {
   resolveBin,
   appDirectory,
-  pkg
+  pkg,
+  log
 };

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -20,7 +20,7 @@ const resolveBin = (moduleName, executable = moduleName) => {
 };
 
 const log = (message) => {
-  console.log(chalk.keyword('salmon')('[jbk-scripts]: ') + message);
+  console.log(chalk.hex('#fa8072')('[jbk-scripts]: ') + message);
 };
 
 module.exports = {


### PR DESCRIPTION
Closes #8 

## Changes

* check for project babel configuration when loading webpack configuration
* define additional utilities
* export default babel config for extensibility reasons
* update README

## Steps to Test

* [x] generate a new project via `@jbknowledge/create-react-app`
* [x] install `jbklabs/react-dev#8-allow-babel-configuration-to-be-overriden-extended`
* [x] `npm start` ---> should work
* [x] make the following `.babelrc.js` file:
```js
module.exports = {};
```
* [x] `npm start` ---> should fail: Error: Can't resolve 'src/views/Dashboard'
* [x] make the following `.babelrc.js` file:
```js
const { babel } = require('@jbknowledge/react-dev');

module.exports = {
  presets: babel.presets.default,
  plugins: babel.plugins.default
}
```
* [x] `npm start` ---> should work again
