### PR TITLE
update default webpack config to include react alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - `lint` command now runs both `eslint` and `prettier` ([#16](https://github.com/JBKLabs/react-dev/issues/16))
+- default webpack configuration to alias `react` ([#20](https://github.com/JBKLabs/react-dev/issues/20))
 
 ## [0.0.1] - 2019-09-19
 ### Added

--- a/src/config/webpackFactory.js
+++ b/src/config/webpackFactory.js
@@ -29,7 +29,10 @@ const webpackFactory = (mode) => {
     mode,
     entry: path.resolve(appDirectory, 'src/index.js'),
     resolve: {
-      extensions: ['.js', '.jsx']
+      extensions: ['.js', '.jsx'],
+      alias: {
+        react: require.resolve('react')
+      }
     },
     output: {
       path: isProduction ? path.resolve(appDirectory, 'dist') : undefined,


### PR DESCRIPTION
Closes #20 

## Changes

- add `alias` key to the default webpack `resolve` section which includes fetches the path of `react`

## Steps to Test

* [x] create a new example in the `react-form` repo within `examples/` via `@jbknowledge/create-react-app`
* [x] update `package.json` replacing the "version" of `@jbk/react-form` with `file:../../`
* [x] `npm start` ---> should fail
* [x] install this branch of `react-dev` explicitly
* [x] `npm start` ---> should work
