### PR TITLE
define a build path arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `--build-path` option to both `build` and `configure` to support existing project's requirements ([#31](https://github.com/JBKLabs/react-dev/issues/31))
+
+### Updated
+- webpack config to utilize a `BUILD_PATH` environment variable for build output which is set by `build` automatically ([#31](https://github.com/JBKLabs/react-dev/issues/31))
+
 ## [0.2.0] - 2019-10-30
 ### Added
 - `eject` script to individually eject one or more of `eslint`, `prettier`, `babel`, and/or `webpack` ([#25](https://github.com/JBKLabs/react-dev/issues/25))

--- a/README.md
+++ b/README.md
@@ -61,11 +61,19 @@ available overrides:
 - webpack config
 - babel config
 
+**options**
+* `--build-path <projectRootRelativePath>`
+  * By default, `jbk-scripts` builds to `./dist`. If you need to change this path, i.e. to `./build`, you can do so using this option.
+
 ### **configure**
 
 `jbk-scripts configure`
 
-configure will inject `ENV_*` into your `public/env.js` file for releases.
+configure will inject `ENV_*` into your `<build>/env.js` file for releases.
+
+**options**
+* `--build-path <projectRootRelativePath>`
+  * By default, `jbk-scripts` assumes you built to `dist` and looks for an `env.js` file at that location. If your build location is different, i.e. `./build`, you can declare that using this option.
 
 ### **eject**
 

--- a/example/package.json
+++ b/example/package.json
@@ -11,7 +11,7 @@
     "eject": "jbk-scripts eject"
   },
   "devDependencies": {
-    "@jbknowledge/react-dev": "^0.1.0"
+    "@jbknowledge/react-dev": "*"
   },
   "dependencies": {
     "@babel/polyfill": "7.6.0",

--- a/lib/src/config/webpack.config.js
+++ b/lib/src/config/webpack.config.js
@@ -14,13 +14,13 @@ const babelPath = find.babelConfig();
 
 const devServer = !isProduction
   ? {
-      historyApiFallback: true,
-      contentBase: path.join(appDirectory, 'public/'),
-      watchContentBase: true,
-      port: 8080,
-      publicPath: '/',
-      hot: true
-    }
+    historyApiFallback: true,
+    contentBase: path.join(appDirectory, 'public/'),
+    watchContentBase: true,
+    port: 8080,
+    publicPath: '/',
+    hot: true
+  }
   : undefined;
 
 module.exports = {
@@ -30,7 +30,7 @@ module.exports = {
     extensions: ['.js', '.jsx']
   },
   output: {
-    path: isProduction ? path.resolve(appDirectory, 'dist') : undefined,
+    path: isProduction ? process.env.BUILD_PATH : undefined,
     publicPath: '/',
     filename: 'static/js/bundle.js'
   },

--- a/lib/src/scripts/build.js
+++ b/lib/src/scripts/build.js
@@ -1,20 +1,24 @@
 const path = require('path');
 const shell = require('shelljs');
 const spawn = require('cross-spawn');
+const parse = require('yargs-parser');
 
 const { appDirectory, log, resolveBin } = require('../util');
 const find = require('../util/find');
 
+const args = parse(process.argv.slice(2));
+const buildPath = path.join(appDirectory, args.buildPath || 'dist');
+
 log.header('Building for production...');
 
 log.debug('preparing output directory');
-shell.rm('-rf', path.join(appDirectory, 'dist'));
-shell.mkdir('-p', path.join(appDirectory, 'dist'));
+shell.rm('-rf', buildPath);
+shell.mkdir('-p', buildPath);
 log.debug('copying public into output directory');
 shell.cp(
   '-rf',
   path.join(appDirectory, 'public/*'),
-  path.join(appDirectory, 'dist')
+  buildPath
 );
 
 const webpackConfig = find.webpackConfig();
@@ -23,6 +27,7 @@ const config = ['--config', webpackConfig];
 
 process.env.NODE_ENV = 'production';
 process.env.BABEL_ENV = 'production';
+process.env.BUILD_PATH = buildPath;
 const result = spawn.sync(resolveBin('webpack'), [...config], {
   stdio: 'inherit'
 });

--- a/lib/src/scripts/configure.js
+++ b/lib/src/scripts/configure.js
@@ -1,7 +1,11 @@
 const path = require('path');
 const shell = require('shelljs');
+const parse = require('yargs-parser');
 
 const { appDirectory } = require('../util');
+
+const args = parse(process.argv.slice(2));
+const buildDir = args.buildPath || 'dist';
 
 Object.entries(process.env)
   .filter(([key]) => key.substr(0, 4) === 'ENV_')
@@ -13,6 +17,6 @@ Object.entries(process.env)
       '-i',
       new RegExp(`${key}: [^,{}]+`),
       `${key}: '${value}'`,
-      path.join(appDirectory, 'dist/env.js')
+      path.join(appDirectory, buildDir, 'env.js')
     );
   });


### PR DESCRIPTION
Closes #31

## Changes
* add `--build-path` arg to `build` and `configure`
* update `build` script to set a value for `BUILD_PATH` to `dist` or the value of `--build-path`
* update webpack config to utilize the `BUILD_PATH` env var

## Steps to Test
* `cd example`
* [x] `yarn build --build-path build` --> build artifacts are there
* [x] export a value for `ENV_ENABLE_DEBUG_MODE`
* [x] `yarn configure --build-path build` --> updates the `env.js` file in `build`
