### PR TITLE
add reasonable defaults to pkg reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- `configure`'s internal reliance on `package.json` file which may or may not exist in runtime environment ([#35](https://github.com/JBKLabs/react-dev/issues/35))
+
 ## [0.3.0] - 2019-11-08
 ### Added
 - `--build-path` option to both `build` and `configure` to support existing project's requirements ([#31](https://github.com/JBKLabs/react-dev/issues/31))

--- a/lib/src/util/index.js
+++ b/lib/src/util/index.js
@@ -6,10 +6,12 @@ const fs = require('fs');
 const readPkgUp = require('read-pkg-up');
 const chalk = require('chalk');
 
-const { package: pkg, path: pkgPath } = readPkgUp.sync({
+const pkgUp = readPkgUp.sync({
   cwd: fs.realpathSync(process.cwd())
 });
-const appDirectory = path.dirname(pkgPath);
+const pkg = pkgUp ? pkgUp.package : null;
+const pkgPath = pkgUp ? pkgUp.path : null;
+const appDirectory = pkgPath ? path.dirname(pkgPath) : process.cwd();
 
 const resolveBin = (moduleName, executable = moduleName) => {
   const modPkgPath = require.resolve(`${moduleName}/package.json`);
@@ -33,14 +35,14 @@ const handleSpawnResult = (result, script) => {
   if (result.signal === 'SIGKILL') {
     console.log(
       `The script "${script}" failed because the process exited too early. ` +
-        'This probably means the system ran out of memory or someone called ' +
-        '`kill -9` on the process.'
+      'This probably means the system ran out of memory or someone called ' +
+      '`kill -9` on the process.'
     );
   } else if (result.signal === 'SIGTERM') {
     console.log(
       `The script "${script}" failed because the process exited too early. ` +
-        'Someone might have called `kill` or `killall`, or the system could ' +
-        'be shutting down.'
+      'Someone might have called `kill` or `killall`, or the system could ' +
+      'be shutting down.'
     );
   } else if (result.signal) {
     process.exit(1);


### PR DESCRIPTION
Closes #35 

## Changes

* util now has reasonable defaults when there is no package.json file

## Steps to Test

* cd example
* run `yarn build`
* export a value for `ENV_ENABLE_DEBUG_MODE`
* [x] run `./node_modules/.bin/jbk-scripts configure` -> should work
* rename `example/package.json` and `package.json` to `no.json`
* export a different value for `ENV_ENABLE_DEBUG_MODE`
* [x] run `./node_modules/.bin/jbk-scripts configure` -> should work
